### PR TITLE
deps: bump GitPython to 3.1.61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "base58check==1.0.2",
   "dnspython==2.7.0",
   "gitdb==4.0.12",
-  "GitPython==3.1.44",
+  "GitPython==3.1.61",
   "motor==3.7.0",
   "mutagen==1.47.0",
   "Pillow==11.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -326,14 +326,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.44"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269", size = 214196, upload-time = "2025-01-02T07:32:43.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761889Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110", size = 207599, upload-time = "2025-01-02T07:32:40.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262613Z" },
 ]
 
 [[package]]
@@ -951,7 +951,7 @@ requires-dist = [
     { name = "base58check", specifier = "==1.0.2" },
     { name = "dnspython", specifier = "==2.7.0" },
     { name = "gitdb", specifier = "==4.0.12" },
-    { name = "gitpython", specifier = "==3.1.44" },
+    { name = "gitpython", specifier = "==3.1.61" },
     { name = "motor", specifier = "==3.7.0" },
     { name = "mutagen", specifier = "==1.47.0" },
     { name = "pillow", specifier = "==11.2.1" },


### PR DESCRIPTION
Updates `GitPython` to address GHSA-284h-m62q-gf8w (critical, CVSS 9.8), GHSA-8mcc-hrx5-hvxc, and GHSA-7833-fr7j-v32q.

Evidence:
- `pyproject.toml` pinned `GitPython==3.1.44`
- OSV (api.osv.dev) reports 44 advisories for GitPython 3.1.44, including the three above
- updated version: `3.1.61`

Validation:
- OSV reports zero advisories for GitPython 3.1.61 (clears every GitPython advisory, not just the three above)
- `uv sync --frozen` resolves and installs against the edited lockfile
- importing `unzipbot` fails identically before and after the change (`config.py` requires `APP_ID` env var at import time; unrelated to this bump)

Note: `uv lock --check` passes on the base branch, so only the gitpython entries were hand-edited (version, specifier, sdist/wheel URL, hash, size from PyPI) instead of regenerating the whole file.

Scope: dependency/lockfile update only.
